### PR TITLE
Fix import for Grails application, fix broken URL for Keycloak download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build/
 .idea/
 *.iml
+resource/out

--- a/client/grails-app/init/client/SecurityConfig.groovy
+++ b/client/grails-app/init/client/SecurityConfig.groovy
@@ -6,7 +6,7 @@ import org.keycloak.adapters.springsecurity.client.KeycloakRestTemplate
 import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
-import org.springframework.boot.web.servlet.ServletListenerRegistrationBean
+import org.springframework.boot.context.embedded.ServletListenerRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -13,7 +13,7 @@ USER keycloak
 ENV KEYCLOAK_VERSION 3.0.0.Final
 ENV KEYCLOAK_HOME /opt/keycloak/keycloak-$KEYCLOAK_VERSION
 
-RUN curl http://download.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz | tar -C $HOME -zx 
+RUN curl https://downloads.jboss.org/keycloak/$KEYCLOAK_VERSION/keycloak-$KEYCLOAK_VERSION.tar.gz | tar -C $HOME -zx 
 RUN $KEYCLOAK_HOME/bin/add-user-keycloak.sh -r master -u admin -p admin
 
 ADD . /opt/keycloak


### PR DESCRIPTION
Fix import for Grails application, fix broken URL for Keycloak download, and update gitignore.

When I tried running the Grails application, I got an error saying that `org.springframework.boot.web.servlet.ServletListenerRegistrationBean` could not be found. IntelliJ suggested `org.springframework.boot.context.embedded.ServletListenerRegistrationBean` as the import and that worked.

The download link for Keycloak has changed to https://downloads.jboss.org/keycloak